### PR TITLE
Update HorizontalPanGesture.swift

### DIFF
--- a/Sources/SlidingRuler/HorizontalPanGesture.swift
+++ b/Sources/SlidingRuler/HorizontalPanGesture.swift
@@ -38,7 +38,7 @@ struct HorizontalDragGestureValue {
     let location: CGPoint
 }
 
-protocol HorizontalPanGestureReceiverViewDelegate: class {
+protocol HorizontalPanGestureReceiverViewDelegate: AnyObject {
     func viewTouchedWithoutPan(_ view: UIView)
 }
 


### PR DESCRIPTION
deprecated usage in swift 5.9, updated to remove warning.