### PR TITLE
Add divisions parameter for ruler subdivisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ By default it is `-V.infinity...V.infinity`.  Meaning that the sliding ruler is 
 The stride of the SlidingRuler.  
 By default it is `1.0`.
 
+#### `divisions` : *`Int`*
+The number of divisions per unit. Must be at least 1.  
+By default it is `10`. This controls how many subdivision marks appear between whole units.
+
 #### `snap` : *`Mark`*
 Possible values : `.none`, `.unit`, `.half`, `.fraction`.
 Describes the ruler's marks stickyness: when the ruler stops and the cursor is near a graduation it will snap to it.
@@ -151,7 +155,7 @@ Describes the ruler's marks stickyness: when the ruler stops and the cursor is n
 By default it is `.none`.
 
 Note: to trigger a snap the cursor must be _near_ the graduation. Here _near_ means that the delta between the cursor and the graduation is strictly less than a fraction of the ruler unit. 
-The value of a fraction is driven by the style's `fractions` property. The default styles have a `fractions` property equal to `10` so a fraction equals to `1/10` of a unit or `0.1` with the default `step` (`1.0`). 
+The value of a fraction is driven by the `divisions` parameter. By default it is `10` so a fraction equals to `1/10` of a unit or `0.1` with the default `step` (`1.0`). 
 
 #### `tick` : *`Mark`*
 Possible values : `.none`, `.unit`, `.half`, `.fraction`.
@@ -196,7 +200,7 @@ By default `SlindingRuler` ships with four styles. Two of them don't show any ma
 <img src="https://raw.githubusercontent.com/Pyroh/SlidingRuler/main/Resources/Styles/BlankCentered.png" width="374pt">
 
 
-### Example
+### Examples
 #### Percentage value
 A SlindingRuler that goes from 0 to 100%, that snaps and gives haptic feedback on any graduation.
 
@@ -220,6 +224,54 @@ struct PercentSlidingRuler: View {
                      snap: .fraction,
                      tick: .fraction,
                      formatter: formatter)
+    }
+}
+
+#### Feet and Inches
+A SlidingRuler configured for feet and inches with 12 divisions per foot:
+
+```Swift
+struct FeetInchesSlidingRuler: View {
+    @State private var value: Double = .zero
+    
+    private var formatter: NumberFormatter {
+        let f = NumberFormatter()
+        f.numberStyle = .decimal
+        f.maximumFractionDigits = 1
+        return f
+    }
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Current Value: \(feetInchesString)")
+                .font(.headline)
+                .padding()
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(8)
+            
+            SlidingRuler(value: $value,
+                         in: 0...10,
+                         step: 1.0,
+                         divisions: 12,  // 12 inches per foot
+                         snap: .fraction,
+                         tick: .fraction,
+                         formatter: formatter)
+        }
+        .padding()
+    }
+    
+    private var feetInchesString: String {
+        let totalInches = value * 12 // Convert feet to total inches
+        let feet = Int(totalInches / 12)
+        let inches = Int(totalInches.truncatingRemainder(dividingBy: 12))
+        
+        if feet == 0 {
+            return "\(inches) inches"
+        } else if inches == 0 {
+            return "\(feet) ft"
+        } else {
+            return "\(feet) ft \(inches) inches"
+        }
     }
 }
 ```

--- a/Sources/SlidingRuler/Ruler/Ruler.swift
+++ b/Sources/SlidingRuler/Ruler/Ruler.swift
@@ -36,6 +36,7 @@ struct Ruler: View, Equatable {
     let step: CGFloat
     let markOffset: CGFloat
     let bounds: ClosedRange<CGFloat>
+    let divisions: Int
     let formatter: NumberFormatter?
     
     var body: some View {
@@ -48,7 +49,7 @@ struct Ruler: View, Equatable {
     }
     
     private func configuration(forCell cell: RulerCell) -> SlidingRulerStyleConfiguation {
-        return .init(mark: (cell.mark + markOffset) * step, bounds: bounds, step: step, formatter: formatter)
+        return .init(mark: (cell.mark + markOffset) * step, bounds: bounds, step: step, divisions: divisions, formatter: formatter)
     }
     
     static func ==(lhs: Self, rhs: Self) -> Bool {
@@ -61,6 +62,6 @@ struct Ruler: View, Equatable {
 struct Ruler_Previews: PreviewProvider {
     static var previews: some View {
         Ruler(cells: [.init(CGFloat(0))],
-              step: 1.0, markOffset: 0, bounds: -1...1, formatter: nil)
+              step: 1.0, markOffset: 0, bounds: -1...1, divisions: 10, formatter: nil)
     }
 }

--- a/Sources/SlidingRuler/Styling/CenteredStyle/BlankCenteredStyle.swift
+++ b/Sources/SlidingRuler/Styling/CenteredStyle/BlankCenteredStyle.swift
@@ -36,7 +36,8 @@ public struct BlankCenteredSlidingRulerStyle: SlidingRulerStyle {
         BlankCenteredCellBody(mark: configuration.mark,
                               bounds: configuration.bounds,
                               step: configuration.step,
-                              cellWidth: cellWidth)
+                              cellWidth: cellWidth,
+                              divisions: configuration.divisions)
     }
 
     public func makeCursorBody() -> some View {

--- a/Sources/SlidingRuler/Styling/CenteredStyle/CenteredCellBody.swift
+++ b/Sources/SlidingRuler/Styling/CenteredStyle/CenteredCellBody.swift
@@ -34,8 +34,9 @@ struct BlankCenteredCellBody: NativeRulerCellView {
     var bounds: ClosedRange<CGFloat>
     var step: CGFloat
     var cellWidth: CGFloat
+    var divisions: Int
 
-    var scale: some ScaleView { CenteredScaleView(width: cellWidth) }
+    var scale: some ScaleView { CenteredScaleView(width: cellWidth, divisions: divisions) }
 }
 
 struct CenteredCellBody: NativeMarkedRulerCellView {
@@ -43,7 +44,8 @@ struct CenteredCellBody: NativeMarkedRulerCellView {
     var bounds: ClosedRange<CGFloat>
     var step: CGFloat
     var cellWidth: CGFloat
+    var divisions: Int
     var numberFormatter: NumberFormatter?
 
-    var cell: some RulerCellView { BlankCenteredCellBody(mark: mark, bounds: bounds, step: step, cellWidth: cellWidth) }
+    var cell: some RulerCellView { BlankCenteredCellBody(mark: mark, bounds: bounds, step: step, cellWidth: cellWidth, divisions: divisions) }
 }

--- a/Sources/SlidingRuler/Styling/CenteredStyle/CenteredScaleView.swift
+++ b/Sources/SlidingRuler/Styling/CenteredStyle/CenteredScaleView.swift
@@ -49,8 +49,8 @@ struct CenteredScaleView: ScaleView {
             p.addRoundedRect(in: halfRect(x: rect.maxX, y: centerY), cornerSize: .init(square: halfMarkSize.width/2))
 
             let divisionWidth = rect.width / CGFloat(divisions)
-            let maxDivisions = divisions - 1
-            for i in 1...maxDivisions {
+            let divisionMarksCount = divisions - 1
+            for i in 1...divisionMarksCount {
                 p.addRoundedRect(in: divisionRect(x: centerX + CGFloat(i) * divisionWidth, y: centerY), cornerSize: .init(square: fractionMarkSize.width/2))
                 p.addRoundedRect(in: divisionRect(x: centerX - CGFloat(i) * divisionWidth, y: centerY), cornerSize: .init(square: fractionMarkSize.width/2))
             }

--- a/Sources/SlidingRuler/Styling/CenteredStyle/CenteredScaleView.swift
+++ b/Sources/SlidingRuler/Styling/CenteredStyle/CenteredScaleView.swift
@@ -30,7 +30,11 @@
 import SwiftUI
 
 struct CenteredScaleView: ScaleView {
+    let divisions: Int
+    
     struct ScaleShape: Shape {
+        let divisions: Int
+        
         fileprivate var unitMarkSize: CGSize { .init(width: 3.0, height: 27.0)}
         fileprivate var halfMarkSize: CGSize { .init(width: UIScreen.main.scale == 3 ? 1.8 : 2.0, height: 19.0) }
         fileprivate var fractionMarkSize: CGSize { .init(width: 1.0, height: 11.0)}
@@ -44,10 +48,11 @@ struct CenteredScaleView: ScaleView {
             p.addRoundedRect(in: halfRect(x: 0, y: centerY), cornerSize: .init(square: halfMarkSize.width/2))
             p.addRoundedRect(in: halfRect(x: rect.maxX, y: centerY), cornerSize: .init(square: halfMarkSize.width/2))
 
-            let tenth = rect.width / 10
-            for i in 1...4 {
-                p.addRoundedRect(in: tenthRect(x: centerX + CGFloat(i) * tenth, y: centerY), cornerSize: .init(square: fractionMarkSize.width/2))
-                p.addRoundedRect(in: tenthRect(x: centerX - CGFloat(i) * tenth, y: centerY), cornerSize: .init(square: fractionMarkSize.width/2))
+            let divisionWidth = rect.width / CGFloat(divisions)
+            let maxDivisions = divisions - 1
+            for i in 1...maxDivisions {
+                p.addRoundedRect(in: divisionRect(x: centerX + CGFloat(i) * divisionWidth, y: centerY), cornerSize: .init(square: fractionMarkSize.width/2))
+                p.addRoundedRect(in: divisionRect(x: centerX - CGFloat(i) * divisionWidth, y: centerY), cornerSize: .init(square: fractionMarkSize.width/2))
             }
 
             return p
@@ -55,19 +60,20 @@ struct CenteredScaleView: ScaleView {
 
         private func unitRect(x: CGFloat, y: CGFloat) -> CGRect { .init(center: .init(x: x, y: y), size: unitMarkSize) }
         private func halfRect(x: CGFloat, y: CGFloat) -> CGRect { .init(center: .init(x: x, y: y), size: halfMarkSize) }
-        private func tenthRect(x: CGFloat, y: CGFloat) -> CGRect { .init(center: .init(x: x, y: y), size: fractionMarkSize) }
+        private func divisionRect(x: CGFloat, y: CGFloat) -> CGRect { .init(center: .init(x: x, y: y), size: fractionMarkSize) }
     }
 
     let width: CGFloat
     let height: CGFloat
-    var shape: ScaleShape { .init() }
+    var shape: ScaleShape { .init(divisions: divisions) }
 
     var unitMarkWidth: CGFloat { shape.unitMarkSize.width }
     var halfMarkWidth: CGFloat { shape.halfMarkSize.width }
     var fractionMarkWidth: CGFloat { shape.fractionMarkSize.width }
 
-    init(width: CGFloat, height: CGFloat = 30) {
+    init(width: CGFloat, height: CGFloat = 30, divisions: Int = 10) {
         self.width = width
         self.height = height
+        self.divisions = divisions
     }
 }

--- a/Sources/SlidingRuler/Styling/CenteredStyle/CenteredStyle.swift
+++ b/Sources/SlidingRuler/Styling/CenteredStyle/CenteredStyle.swift
@@ -37,6 +37,7 @@ public struct CenteredSlindingRulerStyle: SlidingRulerStyle {
                          bounds: configuration.bounds,
                          step: configuration.step,
                          cellWidth: cellWidth,
+                         divisions: configuration.divisions,
                          numberFormatter: configuration.formatter)
     }
 

--- a/Sources/SlidingRuler/Styling/DefaultStyle/BlankStyle.swift
+++ b/Sources/SlidingRuler/Styling/DefaultStyle/BlankStyle.swift
@@ -36,7 +36,8 @@ public struct BlankSlidingRulerStyle: SlidingRulerStyle {
         BlankCellBody(mark: configuration.mark,
                       bounds: configuration.bounds,
                       step: configuration.step,
-                      cellWidth: cellWidth)
+                      cellWidth: cellWidth,
+                      divisions: configuration.divisions)
     }
 
     public func makeCursorBody() -> some View {

--- a/Sources/SlidingRuler/Styling/DefaultStyle/DefaultCellBody.swift
+++ b/Sources/SlidingRuler/Styling/DefaultStyle/DefaultCellBody.swift
@@ -34,8 +34,9 @@ struct BlankCellBody: NativeRulerCellView {
     var bounds: ClosedRange<CGFloat>
     var step: CGFloat
     var cellWidth: CGFloat
+    var divisions: Int
 
-    var scale: some ScaleView { DefaultScaleView(width: cellWidth) }
+    var scale: some ScaleView { DefaultScaleView(width: cellWidth, divisions: divisions) }
 }
 
 struct DefaultCellBody: NativeMarkedRulerCellView {
@@ -43,8 +44,9 @@ struct DefaultCellBody: NativeMarkedRulerCellView {
     var bounds: ClosedRange<CGFloat>
     var step: CGFloat
     var cellWidth: CGFloat
+    var divisions: Int
     var numberFormatter: NumberFormatter?
 
-    var cell: some RulerCellView { BlankCellBody(mark: mark, bounds: bounds, step: step, cellWidth: cellWidth) }
+    var cell: some RulerCellView { BlankCellBody(mark: mark, bounds: bounds, step: step, cellWidth: cellWidth, divisions: divisions) }
 }
 

--- a/Sources/SlidingRuler/Styling/DefaultStyle/DefaultScaleView.swift
+++ b/Sources/SlidingRuler/Styling/DefaultStyle/DefaultScaleView.swift
@@ -30,7 +30,11 @@
 import SwiftUI
 
 struct DefaultScaleView: ScaleView {
+    let divisions: Int
+    
     struct ScaleShape: Shape {
+        let divisions: Int
+        
         fileprivate var unitMarkSize: CGSize { .init(width: 3.0, height: 27.0)}
         fileprivate var halfMarkSize: CGSize { .init(width: UIScreen.main.scale == 3 ? 1.8 : 2.0, height: 19.0) }
         fileprivate var fractionMarkSize: CGSize { .init(width: 1.0, height: 11.0)}
@@ -43,10 +47,11 @@ struct DefaultScaleView: ScaleView {
             p.addRoundedRect(in: halfRect(x: 0), cornerSize: .init(square: halfMarkSize.width/2))
             p.addRoundedRect(in: halfRect(x: rect.maxX), cornerSize: .init(square: halfMarkSize.width/2))
             
-            let tenth = rect.width / 10
-            for i in 1...4 {
-                p.addRoundedRect(in: tenthRect(x: centerX + CGFloat(i) * tenth), cornerSize: .init(square: fractionMarkSize.width/2))
-                p.addRoundedRect(in: tenthRect(x: centerX - CGFloat(i) * tenth), cornerSize: .init(square: fractionMarkSize.width/2))
+            let divisionWidth = rect.width / CGFloat(divisions)
+            let maxDivisions = divisions - 1
+            for i in 1...maxDivisions {
+                p.addRoundedRect(in: divisionRect(x: centerX + CGFloat(i) * divisionWidth), cornerSize: .init(square: fractionMarkSize.width/2))
+                p.addRoundedRect(in: divisionRect(x: centerX - CGFloat(i) * divisionWidth), cornerSize: .init(square: fractionMarkSize.width/2))
             }
             
             return p
@@ -54,14 +59,14 @@ struct DefaultScaleView: ScaleView {
         
         private func unitRect(x: CGFloat) -> CGRect { rect(centerX: x, size: unitMarkSize) }
         private func halfRect(x: CGFloat) -> CGRect { rect(centerX: x, size: halfMarkSize) }
-        private func tenthRect(x: CGFloat) -> CGRect { rect(centerX: x, size: fractionMarkSize) }
+        private func divisionRect(x: CGFloat) -> CGRect { rect(centerX: x, size: fractionMarkSize) }
         
         private func rect(centerX x: CGFloat, size: CGSize) -> CGRect {
             CGRect(origin: .init(x: x - size.width / 2, y: 0), size: size)
         }
     }
 
-    var shape: ScaleShape { .init() }
+    var shape: ScaleShape { .init(divisions: divisions) }
     let width: CGFloat
     let height: CGFloat
 
@@ -69,9 +74,10 @@ struct DefaultScaleView: ScaleView {
     var halfMarkWidth: CGFloat { shape.halfMarkSize.width }
     var fractionMarkWidth: CGFloat { shape.fractionMarkSize.width }
 
-    init(width: CGFloat, height: CGFloat = 30) {
+    init(width: CGFloat, height: CGFloat = 30, divisions: Int = 10) {
         self.width = width
         self.height = height
+        self.divisions = divisions
     }
 }
 

--- a/Sources/SlidingRuler/Styling/DefaultStyle/DefaultScaleView.swift
+++ b/Sources/SlidingRuler/Styling/DefaultStyle/DefaultScaleView.swift
@@ -48,8 +48,8 @@ struct DefaultScaleView: ScaleView {
             p.addRoundedRect(in: halfRect(x: rect.maxX), cornerSize: .init(square: halfMarkSize.width/2))
             
             let divisionWidth = rect.width / CGFloat(divisions)
-            let maxDivisions = divisions - 1
-            for i in 1...maxDivisions {
+            let divisionMarksCount = divisions - 1
+            for i in 1...divisionMarksCount {
                 p.addRoundedRect(in: divisionRect(x: centerX + CGFloat(i) * divisionWidth), cornerSize: .init(square: fractionMarkSize.width/2))
                 p.addRoundedRect(in: divisionRect(x: centerX - CGFloat(i) * divisionWidth), cornerSize: .init(square: fractionMarkSize.width/2))
             }

--- a/Sources/SlidingRuler/Styling/DefaultStyle/DefaultStyle.swift
+++ b/Sources/SlidingRuler/Styling/DefaultStyle/DefaultStyle.swift
@@ -37,6 +37,7 @@ public struct PrimarySlidingRulerStyle: SlidingRulerStyle {
                         bounds: configuration.bounds,
                         step: configuration.step,
                         cellWidth: cellWidth,
+                        divisions: configuration.divisions,
                         numberFormatter: configuration.formatter)
     }
     
@@ -52,9 +53,9 @@ struct DefaultStyle_Previews: PreviewProvider {
 
         var body: some View {
             HStack(spacing: 0) {
-                BlankCellBody(mark: -1, bounds: range, step: 1, cellWidth: width).clipped()
-                BlankCellBody(mark: 0, bounds: range, step: 1, cellWidth: width).clipped()
-                BlankCellBody(mark: 1, bounds: range, step: 1, cellWidth: width).clipped()
+                BlankCellBody(mark: -1, bounds: range, step: 1, cellWidth: width, divisions: 10).clipped()
+                BlankCellBody(mark: 0, bounds: range, step: 1, cellWidth: width, divisions: 10).clipped()
+                BlankCellBody(mark: 1, bounds: range, step: 1, cellWidth: width, divisions: 10).clipped()
             }
         }
     }

--- a/Sources/SlidingRuler/Styling/StyleConfiguation.swift
+++ b/Sources/SlidingRuler/Styling/StyleConfiguation.swift
@@ -34,5 +34,6 @@ public struct SlidingRulerStyleConfiguation {
     let mark: CGFloat
     let bounds: ClosedRange<CGFloat>
     let step: CGFloat
+    let divisions: Int
     let formatter: NumberFormatter?
 }


### PR DESCRIPTION
This pull request introduces a new `divisions` parameter to the `SlidingRuler` component, enhancing its functionality by allowing finer control over the number of subdivisions per unit. It also updates the related documentation, examples, and styling components to reflect this new feature. Below are the key changes grouped by theme:

### Core Functionality Updates:
* Added a `divisions` parameter to `SlidingRuler`, defaulting to 10, with validation ensuring it is at least 1. This parameter determines the number of subdivisions per unit. (`Sources/SlidingRuler/SlidingRuler.swift`: [[1]](diffhunk://#diff-3b790d11e65c7fbd1a1559554f72cfc32c8c20b9e24b2be5210ca1a227908a83R52-R53) [[2]](diffhunk://#diff-3b790d11e65c7fbd1a1559554f72cfc32c8c20b9e24b2be5210ca1a227908a83R124-R145) [[3]](diffhunk://#diff-3b790d11e65c7fbd1a1559554f72cfc32c8c20b9e24b2be5210ca1a227908a83L151-R161)
* Updated internal calculations to replace the `fractions` property with the new `divisions` parameter for snapping and tick behavior. (`Sources/SlidingRuler/SlidingRuler.swift`: [[1]](diffhunk://#diff-3b790d11e65c7fbd1a1559554f72cfc32c8c20b9e24b2be5210ca1a227908a83L320-R330) [[2]](diffhunk://#diff-3b790d11e65c7fbd1a1559554f72cfc32c8c20b9e24b2be5210ca1a227908a83L340-R350) [[3]](diffhunk://#diff-3b790d11e65c7fbd1a1559554f72cfc32c8c20b9e24b2be5210ca1a227908a83L528-R538)

### Styling Updates:
* Modified all ruler styles (`DefaultStyle`, `CenteredStyle`, etc.) to incorporate the `divisions` parameter, ensuring it is used for rendering subdivision marks. (`Sources/SlidingRuler/Styling/DefaultStyle/DefaultCellBody.swift`: [[1]](diffhunk://#diff-5031471a1b828b084a24568eac0fa804d80627a63f8d49ae96f99f92345e51a0R37-R50) [[2]](diffhunk://#diff-8b2bc0673512c24b15db125a630d024069c097575e90684a740c863b7569706fR33-R37); `Sources/SlidingRuler/Styling/CenteredStyle/CenteredCellBody.swift`: [[3]](diffhunk://#diff-48a8a156ba7ca0b7d9fb4ef3dde0bcc53803f0c4282e11fe0280e4afdcbd5eafR37-R50) [[4]](diffhunk://#diff-9f0f54dd4589d68156f2fcac1632dc9d06bfa83ebd4549a7228968d543565ce8R33-R37)

### Documentation Enhancements:
* Updated the `README.md` to include a description of the `divisions` parameter and its default value. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R142-R145) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L154-R158)
* Added a new example for a "Feet and Inches" ruler configuration using the `divisions` parameter. (`README.md`: [README.mdR229-R276](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R229-R276))

### Codebase Refactoring:
* Adjusted the `Ruler` and related components to accept and use the `divisions` parameter for rendering and configuration. (`Sources/SlidingRuler/Ruler/Ruler.swift`: [[1]](diffhunk://#diff-d61306c35f4e1d6e18e8294675ff3e6409834a892c61f3bdb024eda797821937R39) [[2]](diffhunk://#diff-d61306c35f4e1d6e18e8294675ff3e6409834a892c61f3bdb024eda797821937L51-R52) [[3]](diffhunk://#diff-d61306c35f4e1d6e18e8294675ff3e6409834a892c61f3bdb024eda797821937L64-R65)

### Visual Updates:
* Updated the rendering logic in `DefaultScaleView` and `CenteredScaleView` to dynamically calculate subdivision widths based on the `divisions` parameter. (`Sources/SlidingRuler/Styling/DefaultStyle/DefaultScaleView.swift`: [[1]](diffhunk://#diff-8b2bc0673512c24b15db125a630d024069c097575e90684a740c863b7569706fL46-R80); `Sources/SlidingRuler/Styling/CenteredStyle/CenteredScaleView.swift`: [[2]](diffhunk://#diff-9f0f54dd4589d68156f2fcac1632dc9d06bfa83ebd4549a7228968d543565ce8L47-R77)

These changes collectively enhance the flexibility and usability of the `SlidingRuler` component, making it easier to customize for various use cases.Introduces a `divisions` parameter to SlidingRuler, allowing configuration of the number of subdivisions per unit (default 10, minimum 1). Updates all relevant style, cell, and scale view implementations to use this parameter instead of hardcoded values, and improves documentation and examples to reflect the new feature.